### PR TITLE
Chore: update IOS_CAPABILITIES to use latest ios and iphone settings

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,8 +6,8 @@ ANDROID_APP = './apps/android/example.apk'
 
 IOS_CAPABILITIES = {
     platformName:       'iOS',
-    platformVersion:    '13.3',
-    deviceName:         'iPhone 11 Pro',
+    platformVersion:    '15.0',
+    deviceName:         'iPhone 13',
     app:                IOS_APP,
     automationName:     'XCUITest'
 }


### PR DESCRIPTION
This change updates `IOS_CAPABILITIES` to use the latest iOS 15.0 and iphone 13 settings, to work with the current Xcode out-of-the-box